### PR TITLE
Uses `Default (platform).sublime-keymap` instead of a specific keymap

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -67,7 +67,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/User/Unity3DReference (Windows).sublime-keymap",
+                                    "file": "${packages}/User/Default (Windows).sublime-keymap",
                                     "platform": "Windows"
                                 },
                                 "caption": "Key Bindings – User"
@@ -75,7 +75,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/User/Unity3DReference (OSX).sublime-keymap",
+                                    "file": "${packages}/User/Default (OSX).sublime-keymap",
                                     "platform": "OSX"
                                 },
                                 "caption": "Key Bindings – User"
@@ -83,7 +83,7 @@
                             {
                                 "command": "open_file",
                                 "args": {
-                                    "file": "${packages}/User/Unity3DReference (Linux).sublime-keymap",
+                                    "file": "${packages}/User/Default (Linux).sublime-keymap",
                                     "platform": "Linux"
                                 },
                                 "caption": "Key Bindings – User"


### PR DESCRIPTION
`Unity3DReference (platform).sublime-keymap` doestn’t seem to be taken into account by Sublime :(
